### PR TITLE
Add `py.typed` file to indicate the package has type annotations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include pzp/py.typed


### PR DESCRIPTION
This tells mypy (and other type checkers) that it can check the types specified in pzp for any consumers of the library.